### PR TITLE
MacOSX to FreeBSD target Compilation Fixes

### DIFF
--- a/src/forge.nim
+++ b/src/forge.nim
@@ -1,4 +1,4 @@
-import std/[os, osproc, strformat, strutils, sequtils, strtabs]
+import std/[os, osproc, strformat, strutils, sequtils, strtabs, distros]
 import hwylterm/hwylcli
 import forge/lib
 
@@ -103,8 +103,9 @@ proc release(
   if dryrun:
     info "[bold blue]dry run...see below for commands".bb
 
-  if not noMacosSdk and not dryRun and not defined(macosx):
-    fetchSdk()
+  if (not dryRun and not defined(macosx)) or (detectOs(MacOSX)):
+    if not noMacosSdk:
+      fetchSdk()
 
   let rest = parseArgs(posArgs)
 

--- a/src/forge/zig.nim
+++ b/src/forge/zig.nim
@@ -82,6 +82,8 @@ proc inferOs*(t: Triple): string =
     "OpenBSD"
   of "netbsd":
     "NetBSD"
+  of "freebsd":
+    "FreeBSD"
   else:
     ""
 


### PR DESCRIPTION
NOTE: The macos_sdk is required for FreeBSD target to compile correctly. I added a check for whether or not the host was building from a Mac; unless explicitly passed with `—no-macos-sdk`, the first time forge is ran, it defaults to fetching the SDK now.

All other changes have comments in the code about what they are for and why they were needed.

Fixes: #9 