### PR TITLE
New MacOS to FreeBSD Target Fix with MacOS Github Runner Tests

### DIFF
--- a/src/forge/zig.nim
+++ b/src/forge/zig.nim
@@ -82,6 +82,8 @@ proc inferOs*(t: Triple): string =
     "OpenBSD"
   of "netbsd":
     "NetBSD"
+  of "freebsd":
+    "FreeBSD"
   else:
     ""
 


### PR DESCRIPTION
So, I slept a bit and setup a basic test runner for building on Mac only and tested against Zigcc and discovered why #9 was happening in a way that I can show.

### Tests Ran

[Test 1 (unmodified forge code)](https://github.com/thearchivalone/Forge-vs-zigcc-MacOS-to-FreeBSD/actions/runs/19025902262/job/54329464790)

Zigcc test passed because I passed `—os:FreeBSD` to it. Everything else was copied verbatim from the nimble string forge created (with only clang information being switched to zigcc and zigcpp)

Forge failed to target FreeBSD because it wasn’t passing `—os:FreeBSD` to the nimble command string.

[Test 2 (with FreeBSD added to inferOS)](https://github.com/thearchivalone/Forge-vs-zigcc-MacOS-to-FreeBSD/actions/runs/19026627937/job/54331418109)

Here, both Zigcc and Forge passed due to the `—os:FreeBSD` flag generating properly.

### What Happened

Targeting from Windows and Linux passed in my local tests (have multiple PCs and a Docker testbed setup on one) because zig would handle targeting correctly since they’re drastically different operating systems. Because Mac OSX and FreeBSD sort of have grown as siblings, not explicitly setting that flag with inferOS would still allow targeting FreeBSD with my original  changes and the binary would most likely work fine.

Here’s a [good article](https://thenewstack.io/apples-open-source-roots-the-bsd-heritage-behind-macos-and-ios/) about Darwin (the official name of the OS that Mac is built on) and the BSDs. Most of the BSDs are their own separate things or forks of those things.