### PR TITLE
Platform Support Futureproofing

### DIFF
--- a/src/forge.nim
+++ b/src/forge.nim
@@ -55,12 +55,13 @@ proc compile(target: string, dryrun: bool = false, nimble: bool = false, args: s
     rest = parseArgs(args)
     ccArgs = genFlags(target, rest)
     baseCmd = if nimble: "nimble" else: "nim"
+    triple = parseTriple(target)
 
   var compileArgs = @[backend] & ccArgs
 
-  if not noMacosSdk and parseTriple(target).inferOs == "MacOSX" and not defined(macosx):
-    if not dryrun: fetchSdk()
-    compileArgs &= sdkFlags()
+  if not noMacosSdk and triple.inferOs == "MacOSX" and not defined(macosx):
+    if not dryrun: fetchSdk(inferSDK(triple))
+    compileArgs &= sdkFlags(inferSDK(triple))
 
   compileArgs &= rest
 
@@ -104,7 +105,9 @@ proc release(
     info "[bold blue]dry run...see below for commands".bb
 
   if not noMacosSdk and not dryRun and not defined(macosx):
-    fetchSdk()
+    for t in target:
+      let triple = parseTriple(t)
+      fetchSdk(inferSDK(triple))
 
   let rest = parseArgs(posArgs)
 

--- a/src/forge/lib.nim
+++ b/src/forge/lib.nim
@@ -2,8 +2,8 @@ import std/[
   os, strformat, strutils
 ]
 
-import ./[config, term, zig, macos_sdk]
-export config, term, zig, macos_sdk
+import ./[config, term, zig, sdk]
+export config, term, zig, sdk
 
 type
   Build* = object
@@ -57,7 +57,7 @@ proc newBuild*(c: Config, target: string, bin: string): Build =
   result.params = params
   result.outDir = c.outDir / formatDirName(params.format, c.name, c.version, target)
 
-proc args*(b: Build, backend: string, noMacosSdk: bool, rest: openArray[string]): seq[string] =
+proc args*(b: Build, backend: string, noSdk: bool, rest: openArray[string]): seq[string] =
 
   result.add backend
   result.add genFlags(b.triple, rest)
@@ -66,7 +66,7 @@ proc args*(b: Build, backend: string, noMacosSdk: bool, rest: openArray[string])
   result.add "--outdir:" & b.outDir
 
   let t = parseTriple(b.triple)
-  if not noMacosSdk and t.inferOs == "MacOSX" and not defined(macosx):
+  if not noSdk and t.inferOs == "MacOSX" and not defined(macosx):
     result.add sdkFlags(inferSDK(t))
 
   if b.params.args.len > 0:

--- a/src/forge/lib.nim
+++ b/src/forge/lib.nim
@@ -65,8 +65,9 @@ proc args*(b: Build, backend: string, noMacosSdk: bool, rest: openArray[string])
   result.add rest
   result.add "--outdir:" & b.outDir
 
-  if not noMacosSdk and parseTriple(b.triple).inferOs == "MacOSX" and not defined(macosx):
-    result.add sdkFlags()
+  let t = parseTriple(b.triple)
+  if not noMacosSdk and t.inferOs == "MacOSX" and not defined(macosx):
+    result.add sdkFlags(inferSDK(t))
 
   if b.params.args.len > 0:
     result.add b.params.args

--- a/src/forge/macos_sdk.nim
+++ b/src/forge/macos_sdk.nim
@@ -16,12 +16,10 @@
 import std/[appdirs, os, osproc, strformat, paths]
 import ./term
 
-when (NimMajor, NimMinor, NimPatch) <= (2, 2, 0): 
-  template `$`*(x: Path): string =
-    string(x)
-
 let SDK_DIR =  appdirs.getDataDir() / Path("forge/macos_sdk")
 const SDK_REPO_URL = "https://github.com/mitchellh/zig-build-macos-sdk"
+var SDK_COMPILER_ARGS = &"--sysroot={SDK_DIR} -I/include -L/lib"
+var SDK_LINKER_ARGS = &"--sysroot={SDK_DIR} -I/include -L/lib"
 
 proc fetchSdk*(force: bool = false) =
   if dirExists($SDK_DIR):
@@ -35,10 +33,5 @@ proc fetchSdk*(force: bool = false) =
     quit code
 
 proc sdkFlags*(): seq[string] =
-  let
-    macos_lib = quoteShell(&"{SDK_DIR}/lib")
-    macos_include = quoteShell(&"{SDK_DIR}/include")
-    macos_frameworks = quoteShell(&"{SDK_DIR}/Frameworks")
-
-  result.add &"--passC:-I{macos_include} -F{macos_frameworks} -L{macos_lib}"
-  result.add &"--passL:-I{macos_include} -F{macos_frameworks} -L{macos_lib}"
+  result.add &"--passC:{SDK_COMPILER_ARGS} -F/Frameworks"
+  result.add &"--passL:{SDK_LINKER_ARGS} -F/Frameworks"

--- a/src/forge/macos_sdk.nim
+++ b/src/forge/macos_sdk.nim
@@ -13,25 +13,25 @@
   switch("passL", &"-I{macos_include} -F{macos_frameworks} -L{macos_lib}")
 ]#
 
-import std/[appdirs, os, osproc, strformat, paths]
-import ./term
+import std/[os, osproc, strformat, paths]
+import term, zig
 
-let SDK_DIR =  appdirs.getDataDir() / Path("forge/macos_sdk")
-const SDK_REPO_URL = "https://github.com/mitchellh/zig-build-macos-sdk"
-var SDK_COMPILER_ARGS = &"--sysroot={SDK_DIR} -I/include -L/lib"
-var SDK_LINKER_ARGS = &"--sysroot={SDK_DIR} -I/include -L/lib"
+# Almost all non-Windows platforms that need either an SDK or use the OS source code as a sysroot
+#  will need these passed to the compiler and linker; separated for readability
+const SDK_COMPILER_ARGS = "-I/include -L/lib"
+const SDK_LINKER_ARGS = "-I/include -L/lib"
 
-proc fetchSdk*(force: bool = false) =
-  if dirExists($SDK_DIR):
-    if force: removeDir($SDK_DIR)
+proc fetchSdk*(sdk: SDK, force: bool = false) =
+  if dirExists($sdk.dir):
+    if force: removeDir($sdk.dir)
     else: return
-  info "cloning macos sdk to: " & $SDK_DIR
-  createDir($SDK_DIR.parentDir)
-  let (output, code) = execCmdEx(fmt"git clone {SDK_REPO_URL} {quoteShell($SDK_DIR)}")
+  info fmt"cloning {sdk.os} sdk to: " & $sdk.dir
+  createDir($sdk.dir.parentDir)
+  let (output, code) = execCmdEx(fmt"git clone {sdk.url} {quoteShell($sdk.dir)}")
   if code != 0:
     err "git clone failed:\n" & output
     quit code
 
-proc sdkFlags*(): seq[string] =
-  result.add &"--passC:{SDK_COMPILER_ARGS} -F/Frameworks"
-  result.add &"--passL:{SDK_LINKER_ARGS} -F/Frameworks"
+proc sdkFlags*(sdk: SDK): seq[string] =
+  result.add fmt"--passC:--sysroot={sdk.dir} {SDK_COMPILER_ARGS} {sdk.cflags}"
+  result.add &"--passL:--sysroot={sdk.dir} {SDK_LINKER_ARGS} {sdk.lflags}"

--- a/src/forge/sdk.nim
+++ b/src/forge/sdk.nim
@@ -1,4 +1,4 @@
-## fetch the macos sdk for cross-compiling
+## fetch an sdk for cross-compiling
 
 #[
   essentially automate this config.nims snippet (from grabnim) with flags
@@ -15,6 +15,10 @@
 
 import std/[os, osproc, strformat, paths]
 import term, zig
+
+when (NimMajor, NimMinor, NimPatch) <= (2, 2, 0):
+  template `$`*(x: Path): string =
+    string(x)
 
 # Almost all non-Windows platforms that need either an SDK or use the OS source code as a sysroot
 #  will need these passed to the compiler and linker; separated for readability


### PR DESCRIPTION
I’m not sure if you are familiar with [sysroots](https://www.baeldung.com/linux/sysroot) when it comes to cross-compiling, but when I saw how you implemented the macos_sdk code, I wanted to extend it. Because you have as many platforms setup for targeting as you do, there’s always the possibility that Zig may drop support or you may come across a platform that you or a user may want support for but Zig decides not to. This is where my changes come into play (and they will probably need extending).

Most open source operating systems don’t come with SDKs but instead, you build directly against the source code used to build them. You would also pass either `—sysroot` or `—isysroot` (see the sysroot link above for more info) to the linker and compiler so that both look for libraries and headers there instead of relying on the host system for such. In some instances, you may also need to copy some host files into the sysroot.

I also didn’t remove any of the MacOS specific checks until other platforms that need this functionality are determined.